### PR TITLE
libc: Mark libstdc++ as vendor available

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -1980,6 +1980,7 @@ cc_library {
     name: "libstdc++",
     static_ndk_lib: true,
     static_libs: ["libasync_safe"],
+    vendor_available: true,
 
     static: {
         system_shared_libs: [],


### PR DESCRIPTION
A lot of blobs still link this even on 8.1, so allow
devices to build a vendor copy of it.

Change-Id: I2349478ec0507e3a5136fe89f15e7dc4bfc1a03e